### PR TITLE
Fix misleading GitLab CI documentation

### DIFF
--- a/docs/pages/repo/docs/ci/gitlabci.mdx
+++ b/docs/pages/repo/docs/ci/gitlabci.mdx
@@ -47,10 +47,6 @@ Create a file called `.gitlab-ci.yml` in your repository with the following cont
     <Tab>
         ```yaml
         image: node:latest
-        # To use Remote Caching, uncomment the next lines and follow the steps below.
-        # variables:
-        #   TURBO_TOKEN: $TURBO_TOKEN
-        #   TURBO_TEAM: $TURBO_TEAM
         stages:
           - build
         build:
@@ -64,10 +60,6 @@ Create a file called `.gitlab-ci.yml` in your repository with the following cont
     <Tab>
         ```yaml
         image: node:latest
-        # To use Remote Caching, uncomment the next lines and follow the steps below.
-        # variables:
-        #   TURBO_TOKEN: $TURBO_TOKEN
-        #   TURBO_TEAM: $TURBO_TEAM
         stages:
           - build
         build:
@@ -85,10 +77,6 @@ Create a file called `.gitlab-ci.yml` in your repository with the following cont
     <Tab>
         ```yaml
         image: node:latest
-        # To use Remote Caching, uncomment the next lines and follow the steps below.
-        # variables:
-        #   TURBO_TOKEN: $TURBO_TOKEN
-        #   TURBO_TEAM: $TURBO_TEAM
         stages:
           - build
         build:
@@ -101,7 +89,9 @@ Create a file called `.gitlab-ci.yml` in your repository with the following cont
             - pnpm build
             - pnpm test
           cache:
-            key: "$CI_COMMIT_REF_SLUG"
+            key:
+              files:
+                - pnpm-lock.yaml
             paths:
               - .pnpm-store
         ```


### PR DESCRIPTION
The example `.gitlab-ci.yml` code leads you to believe you need to add the `variables` section to enable remote caching. If you actually uncomment those lines and add that section you end up with environment variables with the *literal* values `TURBO_TEAM=$TURBO_TEAM` and `TURBO_TOKEN=$TURBO_TOKEN`.

The `$` variables do **not** get expanded and so when you then add the variables in the UI these have no effect. The correct behaviour is to not add this variables section in the `.gitlab-ci.yml` and just add the variables in the UI.

A further improvement would be for the turbo CLI to print out an error message when the variables are incorrect / when authentication to the caching server fails.

### Description

<!--
  ✍️ Write a short summary of your work.
  If necessary, include relevant screenshots.
-->

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
